### PR TITLE
feat: import frontend module from op-energy-frontend repo

### DIFF
--- a/host.nix
+++ b/host.nix
@@ -1,6 +1,7 @@
 env@{
   GIT_COMMIT_HASH ? ""
 , OP_ENERGY_REPO_LOCATION ? /etc/nixos/.git/modules/overlays/op-energy/modules/oe-blockspan-service
+, OP_ENERGY_FRONTEND_REPO_LOCATION ? /etc/nixos/.git/modules/overlays/op-energy-frontend
 , OP_ENERGY_ACCOUNT_REPO_LOCATION ? /etc/nixos/.git/modules/overlays/op-energy
   # import psk from out-of-git file
 , bitcoind-mainnet-rpc-psk ? builtins.readFile ( "/etc/nixos/private/bitcoind-mainnet-rpc-psk.txt")
@@ -27,7 +28,7 @@ let
         printf $HASH > $out
       ''
     );
-  opEnergyFrontendModule = import ./overlays/op-energy/oe-blockspan-service/frontend/module-frontend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_REPO_LOCATION; };
+  opEnergyFrontendModule = import ./overlays/op-energy-frontend/frontend/module-frontend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_FRONTEND_REPO_LOCATION; };
   opEnergyBackendModule = import ./overlays/op-energy/oe-blockspan-service/op-energy-backend/module-backend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_REPO_LOCATION; };
   opEnergyAccountServiceModule = import ./overlays/op-energy/oe-account-service/op-energy-account-service/module-backend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_ACCOUNT_REPO_LOCATION; };
   internal_blocktime_api_port = import ./internal_blocktime_api_port.nix;


### PR DESCRIPTION
## Summary

Updates `host.nix` to import the frontend module from the new `op-energy-frontend` overlay instead of `oe-blockspan-service`. This enables independent frontend deployments.

## Changes

- Added `OP_ENERGY_FRONTEND_REPO_LOCATION` parameter pointing to the frontend repo's git location
- Changed `opEnergyFrontendModule` import path from `./overlays/op-energy/oe-blockspan-service/frontend/module-frontend.nix` to `./overlays/op-energy-frontend/frontend/module-frontend.nix`

## Context

Per discussion in op-energy-foundation/op-energy-blockspan-service#138:
- `op-energy-frontend` repo created
- `overlays/op-energy-frontend` submodule added to dev-instance
- CI test job confirmed working with new overlay path
- This is the next step: point the NixOS build to use the frontend from the new repo

Ref op-energy-foundation/op-energy-blockspan-service#138